### PR TITLE
Allow Raw SQL in Order Statements

### DIFF
--- a/lib/dm-core/query.rb
+++ b/lib/dm-core/query.rb
@@ -949,6 +949,10 @@ module DataMapper
 
       order.each do |order_entry|
         case order_entry
+          when Direction
+            # DataMapper::Query::Direction is an internal class, so if you're
+            # using it, it's assumed you know what you're doing.
+
           when Symbol, String
             unless @properties.named?(order_entry)
               raise ArgumentError, "+options[:order]+ entry #{order_entry.inspect} does not map to a property in #{model}"
@@ -958,7 +962,7 @@ module DataMapper
             # Allow any arbitrary property, since it may map to a model
             # that has been included via the :links option
 
-          when Operator, Direction
+          when Operator
             operator = order_entry.operator
 
             unless operator == :asc || operator == :desc
@@ -1056,6 +1060,9 @@ module DataMapper
       @order = Array(@order)
       @order = @order.map do |order|
         case order
+          when Direction
+            order.dup
+
           when Operator
             target   = order.target
             property = target.kind_of?(Property) ? target : @properties[target]
@@ -1067,9 +1074,6 @@ module DataMapper
 
           when Property
             Direction.new(order)
-
-          when Direction
-            order.dup
 
           when Path
             Direction.new(order.property)

--- a/spec/semipublic/query_spec.rb
+++ b/spec/semipublic/query_spec.rb
@@ -959,6 +959,18 @@ describe DataMapper::Query do
         end
       end
 
+      describe 'that contains a Query::Direction with something other than a property' do
+        before :all do
+          @property = "something"
+          @direction = DataMapper::Query::Direction.new(@property, :desc)
+          @return = DataMapper::Query.new(@repository, @model, @options.update(:order => [ @direction ]))
+        end
+
+        it 'should set the order, since it may be used by an extension or plugin' do
+          @return.order.should == [ @direction ]
+        end
+      end
+
       describe 'that contains a Query::Direction with a property that is not part of the model' do
         before :all do
           @property = DataMapper::Property::String.new(@model, :unknown)


### PR DESCRIPTION
This commit doesn't _actually_ allow raw SQL in order statements, but enables adapters to define custom behavior for DM::Query::Direction (or child) objects. The changes are quite minimal: essentially we assume that instances of DM::Query::Direction are valid when entering a query; this seems like a reasonable assumption, given that no public API produces a Direction object (which hasn't already been validated), and the Direction class is itself a private API.

This means that Directions are passed directly to the driver to handle, which means, e.g., that the do driver can support other targets than Properties: https://github.com/bernerdschaefer/dm-do-adapter/commit/3f4d6a59f81cd861abef738f3d76c899d71a8d14 to dm-do-adapter.

With these 2 patches together, you can wire something up like this for yourself:

```
class SqlOrder < DataMapper::Query::Direction
end

User.all(:order => SqlOrder.new("(select count(*) from comments where user_id = users.id)", :desc)
```
