### PR TITLE
Performance improvement for many-to-one relationship fetching

### DIFF
--- a/lib/dm-core/associations/many_to_one.rb
+++ b/lib/dm-core/associations/many_to_one.rb
@@ -118,8 +118,12 @@ module DataMapper
         # @api semipublic
         def get(source, query = nil)
           lazy_load(source)
-          collection = get_collection(source)
-          collection.first(query) if collection
+          if query.nil?
+            get!(source)
+          else
+            collection = get_collection(source)
+            collection.first(query) if collection
+          end
         end
 
         def get_collection(source)


### PR DESCRIPTION
Don't build up a collection when fetching without a query.  Cuts time time by ~100x on my system.
