### PR TITLE
optimized OrderedSet#include?(entry)

### DIFF
--- a/lib/dm-core/support/ordered_set.rb
+++ b/lib/dm-core/support/ordered_set.rb
@@ -350,7 +350,7 @@ module DataMapper
     #
     # @api private
     def include?(entry)
-      entries.include?(entry)
+      @cache.include?(entry) && entries[@cache[entry]] == entry
     end
 
     # Return the index for the entry in the set


### PR DESCRIPTION
Optimized OrderSet#include? by using cache here as well. First
look if the key exists in the cache and if it does, compare the
entry with that key with the provided entry.
