### PR TITLE
if order is not defined, "The error occurred while evaluating nil.map" occurs

### DIFF
--- a/lib/dm-core/query.rb
+++ b/lib/dm-core/query.rb
@@ -517,6 +517,7 @@ module DataMapper
     #
     # @api semipublic
     def sort_records(records)
+      return records if order.nil?
       sort_order = order.map { |direction| [ direction.target, direction.operator == :asc ] }
 
       records.sort_by do |record|


### PR DESCRIPTION
if order is not defined, "The error occurred while evaluating nil.map" occurs
