### PR TITLE
Updated shared adapter spec to be more configurable

### DIFF
--- a/lib/dm-core/spec/shared/adapter_spec.rb
+++ b/lib/dm-core/spec/shared/adapter_spec.rb
@@ -22,48 +22,47 @@ share_examples_for 'An Adapter' do
     end
   end
 
+  # Hack to detect cases a let(:heffalump_model) is not present
+  unless instance_methods.map(&:to_s).include?('heffalump_model')
+    # This is the default Heffalup model. You can replace it with your own 
+    # (using let/let!) # but # be shure the replacement provides the required 
+    # properties.
+    let(:heffalump_model) do
+      Class.new do
+        include DataMapper::Resource
+        property :id,        DataMapper::Property::Serial
+        property :color,     DataMapper::Property::String
+        property :num_spots, DataMapper::Property::Integer
+        property :striped,   DataMapper::Property::Boolean
+
+        # This is needed for DataMapper.finalize
+        def self.name; 'Heffalump'; end
+      end
+    end
+  end
 
   before :all do
     raise '+#adapter+ should be defined in a let(:adapter) block' unless respond_to?(:adapter)
     raise '+#repository+ should be defined in a let(:repository) block' unless respond_to?(:repository)
 
-    if respond_to?(:heffalump_model)
-      Object.const_set 'Heffalump', heffalump_model
-    else
-      # This is the default Heffalup model. You can replace it with your own 
-      # (using let/let!) # but # be shure the replacement provides the required 
-      # properties.
-      class ::Heffalump
-        include DataMapper::Resource
-        property :id,        Serial
-        property :color,     String
-        property :num_spots, Integer
-        property :striped,   Boolean
-      end
-    end
-
     DataMapper.finalize
 
     # create all tables and constraints before each spec
     if repository.respond_to?(:auto_migrate!)
-      Heffalump.auto_migrate!
+      heffalump_model.auto_migrate!
     end
-  end
-
-  after :all do
-    Object.send(:remove_const,'Heffalump') if defined? ::Heffalump
   end
 
   if adapter_supports?(:create)
     describe '#create' do
       it 'should not raise any errors' do
         lambda {
-          Heffalump.create(:color => 'peach')
+          heffalump_model.create(:color => 'peach')
         }.should_not raise_error
       end
 
       it 'should set the identity field for the resource' do
-        heffalump = Heffalump.new(:color => 'peach')
+        heffalump = heffalump_model.new(:color => 'peach')
         heffalump.id.should be_nil
         heffalump.save
         heffalump.id.should_not be_nil
@@ -76,19 +75,19 @@ share_examples_for 'An Adapter' do
   if adapter_supports?(:read)
     describe '#read' do
       before :all do
-        @heffalump = Heffalump.create(:color => 'brownish hue')
+        @heffalump = heffalump_model.create(:color => 'brownish hue')
         #just going to borrow this, so I can check the return values
-        @query = Heffalump.all.query
+        @query = heffalump_model.all.query
       end
 
       it 'should not raise any errors' do
         lambda {
-          Heffalump.all()
+          heffalump_model.all()
         }.should_not raise_error
       end
 
       it 'should return stuff' do
-        Heffalump.all.should be_include(@heffalump)
+        heffalump_model.all.should be_include(@heffalump)
       end
     end
   else
@@ -98,7 +97,7 @@ share_examples_for 'An Adapter' do
   if adapter_supports?(:update)
     describe '#update' do
       before do
-        @heffalump = Heffalump.create(:color => 'indigo')
+        @heffalump = heffalump_model.create(:color => 'indigo')
       end
 
       it 'should not raise any errors' do
@@ -118,14 +117,14 @@ share_examples_for 'An Adapter' do
       it 'should update altered fields' do
         @heffalump.color = 'violet'
         @heffalump.save
-        Heffalump.get(*@heffalump.key).color.should == 'violet'
+        heffalump_model.get(*@heffalump.key).color.should == 'violet'
       end
 
       it 'should not alter other fields' do
         color = @heffalump.color
         @heffalump.num_spots = 3
         @heffalump.save
-        Heffalump.get(*@heffalump.key).color.should == color
+        heffalump_model.get(*@heffalump.key).color.should == color
       end
     end
   else
@@ -135,7 +134,7 @@ share_examples_for 'An Adapter' do
   if adapter_supports?(:delete)
     describe '#delete' do
       before do
-        @heffalump = Heffalump.create(:color => 'forest green')
+        @heffalump = heffalump_model.create(:color => 'forest green')
       end
 
       it 'should not raise any errors' do
@@ -147,7 +146,7 @@ share_examples_for 'An Adapter' do
       it 'should delete the requested resource' do
         id = @heffalump.id
         @heffalump.destroy
-        Heffalump.get(id).should be_nil
+        heffalump_model.get(id).should be_nil
       end
     end
   else
@@ -157,97 +156,97 @@ share_examples_for 'An Adapter' do
   if adapter_supports?(:read, :create)
     describe 'query matching' do
       before :all do
-        @red  = Heffalump.create(:color => 'red')
-        @two  = Heffalump.create(:num_spots => 2)
-        @five = Heffalump.create(:num_spots => 5)
+        @red  = heffalump_model.create(:color => 'red')
+        @two  = heffalump_model.create(:num_spots => 2)
+        @five = heffalump_model.create(:num_spots => 5)
       end
 
       describe 'conditions' do
         describe 'eql' do
           it 'should be able to search for objects included in an inclusive range of values' do
-            Heffalump.all(:num_spots => 1..5).should be_include(@five)
+            heffalump_model.all(:num_spots => 1..5).should be_include(@five)
           end
 
           it 'should be able to search for objects included in an exclusive range of values' do
-            Heffalump.all(:num_spots => 1...6).should be_include(@five)
+            heffalump_model.all(:num_spots => 1...6).should be_include(@five)
           end
 
           it 'should not be able to search for values not included in an inclusive range of values' do
-            Heffalump.all(:num_spots => 1..4).should_not be_include(@five)
+            heffalump_model.all(:num_spots => 1..4).should_not be_include(@five)
           end
 
           it 'should not be able to search for values not included in an exclusive range of values' do
-            Heffalump.all(:num_spots => 1...5).should_not be_include(@five)
+            heffalump_model.all(:num_spots => 1...5).should_not be_include(@five)
           end
         end
 
         describe 'not' do
           it 'should be able to search for objects with not equal value' do
-            Heffalump.all(:color.not => 'red').should_not be_include(@red)
+            heffalump_model.all(:color.not => 'red').should_not be_include(@red)
           end
 
           it 'should include objects that are not like the value' do
-            Heffalump.all(:color.not => 'black').should be_include(@red)
+            heffalump_model.all(:color.not => 'black').should be_include(@red)
           end
 
           it 'should be able to search for objects with not nil value' do
-            Heffalump.all(:color.not => nil).should be_include(@red)
+            heffalump_model.all(:color.not => nil).should be_include(@red)
           end
 
           it 'should not include objects with a nil value' do
-            Heffalump.all(:color.not => nil).should_not be_include(@two)
+            heffalump_model.all(:color.not => nil).should_not be_include(@two)
           end
 
           it 'should be able to search for object with a nil value using required properties' do
-            Heffalump.all(:id.not => nil).should == [ @red, @two, @five ]
+            heffalump_model.all(:id.not => nil).should == [ @red, @two, @five ]
           end
 
           it 'should be able to search for objects not in an empty list (match all)' do
-            Heffalump.all(:color.not => []).should == [ @red, @two, @five ]
+            heffalump_model.all(:color.not => []).should == [ @red, @two, @five ]
           end
 
           it 'should be able to search for objects in an empty list and another OR condition (match none on the empty list)' do
-            Heffalump.all(
+            heffalump_model.all(
               :conditions => DataMapper::Query::Conditions::Operation.new(
                 :or,
-                DataMapper::Query::Conditions::Comparison.new(:in, Heffalump.properties[:color], []),
-                DataMapper::Query::Conditions::Comparison.new(:in, Heffalump.properties[:num_spots], [5])
+                DataMapper::Query::Conditions::Comparison.new(:in, heffalump_model.properties[:color], []),
+                DataMapper::Query::Conditions::Comparison.new(:in, heffalump_model.properties[:num_spots], [5])
               )
             ).should == [ @five ]
           end
 
           it 'should be able to search for objects not included in an array of values' do
-            Heffalump.all(:num_spots.not => [ 1, 3, 5, 7 ]).should be_include(@two)
+            heffalump_model.all(:num_spots.not => [ 1, 3, 5, 7 ]).should be_include(@two)
           end
 
           it 'should be able to search for objects not included in an array of values' do
-            Heffalump.all(:num_spots.not => [ 1, 3, 5, 7 ]).should_not be_include(@five)
+            heffalump_model.all(:num_spots.not => [ 1, 3, 5, 7 ]).should_not be_include(@five)
           end
 
           it 'should be able to search for objects not included in an inclusive range of values' do
-            Heffalump.all(:num_spots.not => 1..4).should be_include(@five)
+            heffalump_model.all(:num_spots.not => 1..4).should be_include(@five)
           end
 
           it 'should be able to search for objects not included in an exclusive range of values' do
-            Heffalump.all(:num_spots.not => 1...5).should be_include(@five)
+            heffalump_model.all(:num_spots.not => 1...5).should be_include(@five)
           end
 
           it 'should not be able to search for values not included in an inclusive range of values' do
-            Heffalump.all(:num_spots.not => 1..5).should_not be_include(@five)
+            heffalump_model.all(:num_spots.not => 1..5).should_not be_include(@five)
           end
 
           it 'should not be able to search for values not included in an exclusive range of values' do
-            Heffalump.all(:num_spots.not => 1...6).should_not be_include(@five)
+            heffalump_model.all(:num_spots.not => 1...6).should_not be_include(@five)
           end
         end
 
         describe 'like' do
           it 'should be able to search for objects that match value' do
-            Heffalump.all(:color.like => '%ed').should be_include(@red)
+            heffalump_model.all(:color.like => '%ed').should be_include(@red)
           end
 
           it 'should not search for objects that do not match the value' do
-            Heffalump.all(:color.like => '%blak%').should_not be_include(@red)
+            heffalump_model.all(:color.like => '%blak%').should_not be_include(@red)
           end
         end
 
@@ -260,75 +259,75 @@ share_examples_for 'An Adapter' do
           end
 
           it 'should be able to search for objects that match value' do
-            Heffalump.all(:color => /ed/).should be_include(@red)
+            heffalump_model.all(:color => /ed/).should be_include(@red)
           end
 
           it 'should not be able to search for objects that do not match the value' do
-            Heffalump.all(:color => /blak/).should_not be_include(@red)
+            heffalump_model.all(:color => /blak/).should_not be_include(@red)
           end
 
           it 'should be able to do a negated search for objects that match value' do
-            Heffalump.all(:color.not => /blak/).should be_include(@red)
+            heffalump_model.all(:color.not => /blak/).should be_include(@red)
           end
 
           it 'should not be able to do a negated search for objects that do not match value' do
-            Heffalump.all(:color.not => /ed/).should_not be_include(@red)
+            heffalump_model.all(:color.not => /ed/).should_not be_include(@red)
           end
 
         end
 
         describe 'gt' do
           it 'should be able to search for objects with value greater than' do
-            Heffalump.all(:num_spots.gt => 1).should be_include(@two)
+            heffalump_model.all(:num_spots.gt => 1).should be_include(@two)
           end
 
           it 'should not find objects with a value less than' do
-            Heffalump.all(:num_spots.gt => 3).should_not be_include(@two)
+            heffalump_model.all(:num_spots.gt => 3).should_not be_include(@two)
           end
         end
 
         describe 'gte' do
           it 'should be able to search for objects with value greater than' do
-            Heffalump.all(:num_spots.gte => 1).should be_include(@two)
+            heffalump_model.all(:num_spots.gte => 1).should be_include(@two)
           end
 
           it 'should be able to search for objects with values equal to' do
-            Heffalump.all(:num_spots.gte => 2).should be_include(@two)
+            heffalump_model.all(:num_spots.gte => 2).should be_include(@two)
           end
 
           it 'should not find objects with a value less than' do
-            Heffalump.all(:num_spots.gte => 3).should_not be_include(@two)
+            heffalump_model.all(:num_spots.gte => 3).should_not be_include(@two)
           end
         end
 
         describe 'lt' do
           it 'should be able to search for objects with value less than' do
-            Heffalump.all(:num_spots.lt => 3).should be_include(@two)
+            heffalump_model.all(:num_spots.lt => 3).should be_include(@two)
           end
 
           it 'should not find objects with a value less than' do
-            Heffalump.all(:num_spots.gt => 2).should_not be_include(@two)
+            heffalump_model.all(:num_spots.gt => 2).should_not be_include(@two)
           end
         end
 
         describe 'lte' do
           it 'should be able to search for objects with value less than' do
-            Heffalump.all(:num_spots.lte => 3).should be_include(@two)
+            heffalump_model.all(:num_spots.lte => 3).should be_include(@two)
           end
 
           it 'should be able to search for objects with values equal to' do
-            Heffalump.all(:num_spots.lte => 2).should be_include(@two)
+            heffalump_model.all(:num_spots.lte => 2).should be_include(@two)
           end
 
           it 'should not find objects with a value less than' do
-            Heffalump.all(:num_spots.lte => 1).should_not be_include(@two)
+            heffalump_model.all(:num_spots.lte => 1).should_not be_include(@two)
           end
         end
       end
 
       describe 'limits' do
         it 'should be able to limit the objects' do
-          Heffalump.all(:limit => 2).length.should == 2
+          heffalump_model.all(:limit => 2).length.should == 2
         end
       end
     end


### PR DESCRIPTION
The intention is to use the shared adapter specs from
dm-mongo-adapter without the need to duplicate it.

Tested against sqlite-adapter mongo-adapter and in-memory adapter, on
ruby-1.9.2-p180.
