### PR TITLE
Documentation update; call super when overriding accessors

### DIFF
--- a/lib/dm-core/property.rb
+++ b/lib/dm-core/property.rb
@@ -80,7 +80,6 @@ module DataMapper
   #    property :title, String
   #
   #    def title=(new_title)
-  #      super
   #      raise ArgumentError if new_title != 'Lee is l337'
   #      super(new_title)
   #    end


### PR DESCRIPTION
Hi there,

I noticed that if I override the accessors for a particular property following the instructions in the current documentation then the validations e.g. `validates_uniqueness_of...` are no longer active. A call to `super` has to be made for the validators to become active again.

A simplified example:

```
module BJK
  class User
    include DataMapper::Resource

    property :id, Serial, :lazy => false
    property :email_address, Text, :lazy => false

    validates_presence_of :email_address
    validates_uniqueness_of :email_address

    def email_address=(new_email_address)
       super # required for validation
       @email_address = new_email_address.downcase
    end
  end
end
```

The following test snippets pass **only** if `super` is called above:

```
user1 = BJK::User.create(:email_address => 'lee@leereilly.net')
user2 = BJK::User.new(:email_address => 'lee@leereilly.net')
user3 = BJK::User.new(:email_address => 'LEE@LEEREILLY.net')

user2.valid?.should == false
user2.valid?.should == false
```

Cheers,
  Lee :beer:
