### PR TITLE
Bugfix in 1.2.0.rc1: Binary properties are not binary ;)

### DIFF
--- a/lib/dm-core/property/binary.rb
+++ b/lib/dm-core/property/binary.rb
@@ -3,14 +3,18 @@ module DataMapper
     class Binary < String
       include PassThroughLoadDump
 
-      def load(value)
-        super.force_encoding("BINARY") if value
+      if RUBY_VERSION >= "1.9"
+
+        def load(value)
+          super.dup.force_encoding("BINARY") if value
+        end
+
+        def dump(value)
+          super.dup.force_encoding("BINARY") if value
+        end
+
       end
 
-      def dump(value)
-        super.force_encoding("BINARY") if value
-      end
-      
     end # class Binary
   end # class Property
 end # module DataMapper

--- a/spec/public/property/binary_spec.rb
+++ b/spec/public/property/binary_spec.rb
@@ -20,20 +20,22 @@ describe DataMapper::Property::Binary do
     it { should eql(:primitive => @primitive, :length => 50) }
   end
 
-  describe 'encoding' do
-    let(:model) do
-      Class.new do
-        include ::DataMapper::Resource
-        property :bin_data, ::DataMapper::Property::Binary
+  if RUBY_VERSION >= "1.9"
+    describe 'encoding' do
+      let(:model) do
+        Class.new do
+          include ::DataMapper::Resource
+          property :bin_data, ::DataMapper::Property::Binary
+        end
       end
-    end
 
-    it 'should always dump with BINARY' do
-      model.bin_data.dump("foo").encoding.names.should include("BINARY")
-    end
+      it 'should always dump with BINARY' do
+        model.bin_data.dump("foo".freeze).encoding.names.should include("BINARY")
+      end
 
-    it 'should always load with BINARY' do
-      model.bin_data.load("foo").encoding.names.should include("BINARY")
+      it 'should always load with BINARY' do
+        model.bin_data.load("foo".freeze).encoding.names.should include("BINARY")
+      end
     end
   end
 end


### PR DESCRIPTION
This fixes an issue with `DataMapper::Ext.blank?` (and other equivalents) trying to validate the length of a Binary property and raising an Exception "ArgumentError: invalid byte sequence in UTF-8", as it attempts to use a regexp (`/\S/`) on the binary data without specifying that it is not UTF-8.  This seems to be directly affecting dm-validations as of 1.2.0.rc1 :)
