### PR TITLE
Support Postgres unbound varchars

### DIFF
--- a/lib/dm-core/property.rb
+++ b/lib/dm-core/property.rb
@@ -812,7 +812,7 @@ module DataMapper
             end
 
           when :length
-            assert_kind_of "options[:#{key}]", value, Range, ::Integer
+            assert_kind_of "options[:#{key}]", value, Range, ::Integer, NilClass
 
           when :size, :precision, :scale
             assert_kind_of "options[:#{key}]", value, ::Integer


### PR DESCRIPTION
Permit the :length option of a property to be nil, to support Postgres' unbound varchars.
