### PR TITLE
Change Direction/Operator precedence (fixes regression at d4377a9ee407b48

### DIFF
--- a/lib/dm-core/query.rb
+++ b/lib/dm-core/query.rb
@@ -1053,6 +1053,9 @@ module DataMapper
       @order = Array(@order)
       @order = @order.map do |order|
         case order
+          when Direction
+            order.dup
+
           when Operator
             target   = order.target
             property = target.kind_of?(Property) ? target : @properties[target]
@@ -1064,9 +1067,6 @@ module DataMapper
 
           when Property
             Direction.new(order)
-
-          when Direction
-            order.dup
 
           when Path
             Direction.new(order.property)


### PR DESCRIPTION
`Direction` descends from `Operator`, yet it appears _after_ `Operator` in the `case..when` statement here.  As a result, any `Direction` used here is rebuilt from the concrete class, which makes it impossible to subclass (as I need to do for part of an extension).
