### PR TITLE
Fixes for assertions of valid properties

### DIFF
--- a/lib/dm-core/query.rb
+++ b/lib/dm-core/query.rb
@@ -787,10 +787,10 @@ module DataMapper
 
       model = self.model
 
-      valid_properties = model.properties
+      valid_properties = model.properties(model.repository)
 
       model.descendants.each do |descendant|
-        valid_properties += descendant.properties
+        valid_properties += descendant.properties(descendant.repository)
       end
 
       fields.each do |field|


### PR DESCRIPTION
I have a case where I have two repositories that have properties of same names, but different types. Assertion fails here because list of properties is alway fetched from the default repo.
