### PR TITLE
Fix for dm-mysql2-adapter loading problem

### DIFF
--- a/lib/dm-core/adapters.rb
+++ b/lib/dm-core/adapters.rb
@@ -208,7 +208,10 @@ module DataMapper
       #
       # @api private
       def normalize_adapter_name(name)
-        (original = name.to_s) == 'sqlite3' ? 'sqlite' : original
+        original = name.to_s
+        return 'sqlite' if original == 'sqlite3'
+        return 'mysql' if original == 'mysql2'
+        original
       end
 
     end


### PR DESCRIPTION
Added conditional for mysql2 adapter so that dm-mysql2-adapter isn't loaded. (the gem name is dm-mysql-adapter)

Many people are running into issues when they are using "mysql2" as the adapter in their database.yml file. The incorrect gem name is being loaded—causing rake tasks to fail.

Here is one example: http://stackoverflow.com/questions/6800284/dm-mysql2-adapter-loaderror-but-why
