### PR TITLE
DataMapper::Hook .method_added and .singleton_method_added should call super

### DIFF
--- a/lib/dm-core/support/hook.rb
+++ b/lib/dm-core/support/hook.rb
@@ -30,10 +30,12 @@ module DataMapper
         class << self
           def method_added(name)
             process_method_added(name, :instance)
+            super
           end
 
           def singleton_method_added(name)
             process_method_added(name, :class)
+            super
           end
         end
       end


### PR DESCRIPTION
Otherwise, any other included modules that rely on those methods
won't work properly. Plus, it's the polite thing to do :)
