### PR TITLE
This fixes lighthouse#1475, results incorrectly marked as immutable

### DIFF
--- a/lib/dm-core/model.rb
+++ b/lib/dm-core/model.rb
@@ -588,7 +588,8 @@ module DataMapper
             model     = discriminator && discriminator.load(record[discriminator]) || self
             model_key = model.key(repository_name)
 
-            resource = if model_key.valid?(key_values = record.values_at(*model_key))
+            key_values = model_key.zip(record.values_at(*model_key)).map { |k,v| k.load(v) }
+            resource = if model_key.valid?(key_values)
               identity_map = repository.identity_map(model)
               identity_map[key_values]
             end


### PR DESCRIPTION
Model#load checks the validity of the fields in the PK when determining if the
object returned should be live or immutable.  Unfortunately, it checks the raw
values rather than the loaded values, resulting in data incorrectly marked as
immutable if the PK countains fields (Enum, Flag, etc.) that are stored in a
different format than the format in which they are represented within the
application.

This fixes the bug by loading the values that make up the PK before checking their
validity.

For a description of the symptoms, see the thread linked to from:

http://datamapper.lighthouseapp.com/projects/20609/tickets/1475-strange-immutable-error
