### PR TITLE
use before each in lieu of before all in shared_adapter spec

### DIFF
--- a/lib/dm-core/spec/shared/adapter_spec.rb
+++ b/lib/dm-core/spec/shared/adapter_spec.rb
@@ -45,7 +45,7 @@ share_examples_for 'An Adapter' do
     end
   end
 
-  before :all do
+  before do
     raise '+#adapter+ should be defined in a let(:adapter) block' unless respond_to?(:adapter)
     raise '+#repository+ should be defined in a let(:repository) block' unless respond_to?(:repository)
 
@@ -78,7 +78,7 @@ share_examples_for 'An Adapter' do
 
   if adapter_supports?(:read)
     describe '#read' do
-      before :all do
+      before do
         @heffalump = heffalump_model.create(:color => 'brownish hue')
         #just going to borrow this, so I can check the return values
         @query = heffalump_model.all.query
@@ -159,7 +159,8 @@ share_examples_for 'An Adapter' do
 
   if adapter_supports?(:read, :create)
     describe 'query matching' do
-      before :all do
+      before do
+        adapter.reset if adapter.respond_to?(:reset)
         @red  = heffalump_model.create(:color => 'red')
         @two  = heffalump_model.create(:num_spots => 2)
         @five = heffalump_model.create(:num_spots => 5)


### PR DESCRIPTION
this keeps each individual spec more clearly isolated from one another, while it should also alleviate some pain for adapter developers with regards to cleaning up databases after each spec run.

when writing an adapter, neither a simple truncation or transactional cleanup at each spec would give the expected behavior of a clean slate after each spec run. 
