### PR TITLE
Fix for Collection#slice incorrect offset adjustments for chained negative offsets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,8 @@ measurements
 .bundle
 Gemfile.*
 
+## RVM
+.rvmrc
+
 ## PROJECT::SPECIFIC
 spec/db/

--- a/lib/dm-core/collection.rb
+++ b/lib/dm-core/collection.rb
@@ -1412,12 +1412,24 @@ module DataMapper
       query = self.query
 
       if offset >= 0
-        query.slice(offset, limit)
+        if query.add_reversed?
+          query.slice(query.limit - limit - offset, limit)
+        else
+          query.slice(offset, limit)
+        end
       else
-        query = query.slice((limit + offset).abs, limit).reverse!
+        if query.limit
+          if query.add_reversed?
+            query.slice(-offset - limit, limit)
+          else  
+            query.slice(query.limit + offset, limit)
+          end
+        else
+          query = query.slice((limit + offset).abs, limit).reverse!
 
-        # tell the Query to prepend each result from the adapter
-        query.update(:add_reversed => !query.add_reversed?)
+          # tell the Query to prepend each result from the adapter
+          query.update(:add_reversed => !query.add_reversed?)
+        end
       end
     end
 

--- a/spec/public/shared/collection_shared_spec.rb
+++ b/spec/public/shared/collection_shared_spec.rb
@@ -1182,6 +1182,78 @@ share_examples_for 'A public Collection' do
       end
     end
 
+    describe 'with chained negative offset after positive' do
+      before :all do
+        unless @skip
+          @return = @resources = @articles.slice!(1, 6).slice!(-4, 3)
+        end
+      end
+
+      it 'should return a Collection' do
+        @return.should be_kind_of(DataMapper::Collection)
+      end
+
+      it 'should return the expected Resources' do
+        @return.should == @copy.entries.slice!(1, 6).slice!(-4, 3)
+      end
+
+      it 'should remove the Resources from the Collection' do
+        @resources.each { |resource| @articles.should_not be_include(resource) }
+      end
+
+      it 'should scope the Collection' do
+        @resources.reload.should == @copy.entries.slice!(1, 6).slice!(-4, 3)
+      end
+    end
+
+    describe 'with chained positive offset after negative' do
+      before :all do
+        unless @skip
+          @return = @resources = @articles.slice!(-6, 5).slice!(1, 2)
+        end
+      end
+
+      it 'should return a Collection' do
+        @return.should be_kind_of(DataMapper::Collection)
+      end
+
+      it 'should return the expected Resources' do
+        @return.should == @copy.entries.slice!(-6, 5).slice!(1, 2)
+      end
+
+      it 'should remove the Resources from the Collection' do
+        @resources.each { |resource| @articles.should_not be_include(resource) }
+      end
+
+      it 'should scope the Collection' do
+        @resources.reload.should == @copy.entries.slice!(-6, 5).slice!(1, 2)
+      end
+    end
+    
+    describe 'with chained negative offset after negative' do
+      before :all do
+        unless @skip
+          @return = @resources = @articles.slice!(-7, 6).slice!(-4, 2)
+        end
+      end
+
+      it 'should return a Collection' do
+        @return.should be_kind_of(DataMapper::Collection)
+      end
+
+      it 'should return the expected Resources' do
+        @return.should == @copy.entries.slice!(-7, 6).slice!(-4, 2)
+      end
+
+      it 'should remove the Resources from the Collection' do
+        @resources.each { |resource| @articles.should_not be_include(resource) }
+      end
+
+      it 'should scope the Collection' do
+        @resources.reload.should == @copy.entries.slice!(-7, 6).slice!(-4, 2)
+      end
+    end
+
     describe 'with an offset not within the Collection' do
       before :all do
         unless @skip

--- a/spec/semipublic/shared/subject_shared_spec.rb
+++ b/spec/semipublic/shared/subject_shared_spec.rb
@@ -3,13 +3,17 @@ share_examples_for 'A semipublic Subject' do
     describe 'with a default' do
       subject { @subject_with_default.default? }
 
-      it { should be(true) }
+      it "default?" do 
+        should be(true)
+      end
     end
 
     describe 'without a default' do
       subject { @subject_without_default.default? }
 
-      it { should be(false) }
+      it "default?" do
+        should be(false)
+      end
     end
   end
 


### PR DESCRIPTION
Existing processing of offset does not account for pre-existing query conditions (such as limit and add_reversed?), thus breaking all cases of chained application of #slice where at least one offset is negative.

Tests for such cases added. 

This change can be used as a base for chained #last behavior fix (also broken)
