### PR TITLE
changes to support multiple threads in jruby--fixes github issue #188

### DIFF
--- a/lib/dm-core/support/logger.rb
+++ b/lib/dm-core/support/logger.rb
@@ -124,7 +124,9 @@ module DataMapper
     # Flush the entire buffer to the log object.
     def flush
       return unless @buffer.size > 0
-      @log.write(@buffer.slice!(0..-1).join)
+      to_flush = @buffer
+      @buffer = []
+      @log.write(to_flush.join)
     end
 
     # Close and remove the current log object.


### PR DESCRIPTION
Prevents the ConcurrencyError in jruby by replacing the buffer array vs. modifying it.  It was the 'slice' that was causing the issue, as threads could be writing to the array during the slice operation and jruby doesn't like that.
