### PR TITLE
fixes resource mass-assignment to ignore private / unknown properties in lieu of exceptions

### DIFF
--- a/lib/dm-core/resource.rb
+++ b/lib/dm-core/resource.rb
@@ -317,8 +317,6 @@ module DataMapper
           when String, Symbol
             if model.allowed_writer_methods.include?(setter = "#{name}=")
               __send__(setter, value)
-            else
-              raise ArgumentError, "The attribute '#{name}' is not accessible in #{model}"
             end
           when Associations::Relationship, Property
             self.persistence_state = persistence_state.set(name, value)

--- a/lib/dm-core/spec/shared/resource_spec.rb
+++ b/lib/dm-core/spec/shared/resource_spec.rb
@@ -243,10 +243,9 @@ share_examples_for 'A public Resource' do
     end
 
     describe 'when a non-public mutator is specified' do
-      it 'should raise an exception' do
-        lambda {
-          @user.attributes = { :admin => true }
-        }.should raise_error(ArgumentError, "The attribute \'admin\' is not accessible in #{@user_model}")
+      it 'should not set the value' do
+        @user.attributes = { :admin => true }
+        @user.attributes[:admin].should be_nil
       end
     end
   end


### PR DESCRIPTION
I was getting frustrated by the following unexpected behavior:

```
model = Model.new params[:model]
# => ArgumentError: The attribute _x_ is not accessible
```

The patch simply deletes this line: https://github.com/datamapper/dm-core/blob/master/lib/dm-core/resource.rb#L321

It's helpful to silence the errors, so I don't have to worry about the exact structure of the JSON getting thrown at the server. Instead, I can safely mass-assign and get the properties I want. 
