### PR TITLE
Use #to_datetime (if available) when typecasting

### DIFF
--- a/lib/dm-core/property/date_time.rb
+++ b/lib/dm-core/property/date_time.rb
@@ -17,7 +17,9 @@ module DataMapper
       #
       # @api private
       def typecast_to_primitive(value)
-        if value.is_a?(::Hash) || value.respond_to?(:to_mash)
+        if value.respond_to?(:to_datetime)
+          value.to_datetime
+        elsif value.is_a?(::Hash) || value.respond_to?(:to_mash)
           typecast_hash_to_datetime(value)
         else
           ::DateTime.parse(value.to_s)

--- a/spec/semipublic/property/date_time_spec.rb
+++ b/spec/semipublic/property/date_time_spec.rb
@@ -12,6 +12,14 @@ describe DataMapper::Property::DateTime do
   it_should_behave_like 'A semipublic Property'
 
   describe '#typecast_to_primitive' do
+    describe 'and value responds to #to_datetime' do
+      it 'uses its return value' do
+        result = @property.typecast(Time.at(123.456))
+        result.should be_kind_of(DateTime)
+        result.strftime('%s%3N').should eql('123456')
+      end
+    end
+
     describe 'and value given as a hash with keys like :year, :month, etc' do
       it 'builds a DateTime instance from hash values' do
         result = @property.typecast(


### PR DESCRIPTION
This adds a `#to_datetime` check to the DateTime property's `#typecast` method, mirroring the `#to_date` and `#to_time` checks already in the Date and Time properties.

I need this because I have an adapter returning Time instances, and the fractional seconds were being truncated by the current DateTime's `#typecast`.