### PR TITLE
Relax addressable requirement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source :rubygems
 
 gemspec
 
-gem 'virtus', '~> 0.5', :git => 'https://github.com/solnic/virtus'
+gem 'virtus', '~> 0.5', :git => 'https://github.com/solnic/virtus', tag: 'v0.5.4'
 
 SOURCE         = ENV.fetch('SOURCE', :git).to_sym
 REPO_POSTFIX   = SOURCE == :path ? ''                                : '.git'

--- a/dm-core.gemspec
+++ b/dm-core.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = [ "lib" ]
   gem.version       = DataMapper::VERSION
 
-  gem.add_runtime_dependency('addressable', '~> 2.2.6')
+  gem.add_runtime_dependency('addressable', '~> 2.2')
   gem.add_runtime_dependency('virtus',      '~> 0.5')
 
   gem.add_development_dependency('rake',  '~> 0.9.2')


### PR DESCRIPTION
Trying to use dm-core HEAD failed for me because:

```
Bundler could not find compatible versions for gem "addressable":
  In Gemfile:
    dm-core (>= 0) ruby depends on
      addressable (~> 2.2.6) ruby

    launchy (~> 2.4.2) ruby depends on
      addressable (2.3.5)
```
This PR relaxes the addressable requirement.  Before and after this change I was getting 3 spec failures.