### PR TITLE
Fix the casting from String to Numeric for zero-leading values

### DIFF
--- a/lib/dm-core/property/typecast/numeric.rb
+++ b/lib/dm-core/property/typecast/numeric.rb
@@ -15,7 +15,7 @@ module DataMapper
         # @api private
         def typecast_to_numeric(value, method)
           if value.respond_to?(:to_str)
-            if value.to_str =~ /\A(-?(?:0|[1-9]\d*)(?:\.\d+)?|(?:\.\d+))\z/
+            if value.to_str =~ /\A(-?(?:[0-9]\d*)(?:\.\d+)?|(?:\.\d+))\z/
               $1.send(method)
             else
               value


### PR DESCRIPTION
At the moment, when assigning a numeric String beginning with a '0'-character to a Number value, Model.valid? returns true while Model.save fails. This is a fix, borrowed from https://github.com/solnic/virtus/pull/124