### PR TITLE
Pass true to respond_to?

### DIFF
--- a/lib/dm-core/support/hook.rb
+++ b/lib/dm-core/support/hook.rb
@@ -168,7 +168,7 @@ module DataMapper
       def register_hook(target_method, scope)
         if scope == :instance && !method_defined?(target_method)
           raise ArgumentError, "#{target_method} instance method does not exist"
-        elsif scope == :class && !respond_to?(target_method)
+        elsif scope == :class && !respond_to?(target_method, true)
           raise ArgumentError, "#{target_method} class method does not exist"
         end
 


### PR DESCRIPTION
`true` in respond_to? as the second arg should allow registering of protected methods as hooks.

Resolves https://github.com/datamapper/dm-core/issues/277