### PR TITLE
Start to remove old rubies from the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,9 @@
 language: ruby
 
 rvm:
-  - ree
-  - 1.8.7
-  - 1.9.3
   - 2.0.0
   - ruby-head
-  - rbx-18mode
   - rbx-19mode
-  - jruby-18mode
 
 env:
   - "ADAPTER=in_memory"


### PR DESCRIPTION
After having a brief conversation with @dkubb, we felt it was best to remove Travis CI runs for ruby versions no longer supported.