### PR TITLE
Addressable 2.4.0 breaks in_memory as a scheme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ services:
   - postgresql
 
 before_install:
+  - gem install bundler
   - sudo apt-get update -qq
   - sudo apt-get install -y postgresql-server-dev-all
 

--- a/dm-core.gemspec
+++ b/dm-core.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files       = `git ls-files -- spec/*`.split($/)
   gem.extra_rdoc_files = %w[LICENSE README.md]
 
-  gem.add_runtime_dependency('addressable', '~> 2.3', '>= 2.3.5')
+  gem.add_runtime_dependency('addressable', '~> 2.3.0', '>= 2.3.5')
 
   gem.add_development_dependency('rake',  '~> 10.0.3')
   gem.add_development_dependency('rspec', '~> 1.3.2')


### PR DESCRIPTION
Hold at 2.3.x until we can change that.

This should fix the failing travis-ci.